### PR TITLE
Changed hard-coded 900 second timeout to accept allocateNode's command

### DIFF
--- a/etc/templates/glidein_condor_config.template
+++ b/etc/templates/glidein_condor_config.template
@@ -27,7 +27,7 @@ ALLOW_READ = 141.142.*
 NUM_CPUS=$SLOTS
 ####################################################################################
 
-STARTD_NOCLAIM_SHUTDOWN=900.0
+STARTD_NOCLAIM_SHUTDOWN=$GLIDEIN_SHUTDOWN
 
 
 


### PR DESCRIPTION
line argument, or the default if it's not used.